### PR TITLE
Update player URL path

### DIFF
--- a/crunchy-xml-decoder/altfuncs.py
+++ b/crunchy-xml-decoder/altfuncs.py
@@ -38,21 +38,21 @@ def config():
     return [lang, lang2, forcesub, forceusa, localizecookies, quality, onlymainsub]
 
 
-def playerrev(url):
-    global player_revision 
-
-    revision_regex = r"swfobject.embedSWF\(\"(?:.+)'(?P<revision>[\d.]+)'(?:.+)\)"
-    try:
-        player_revision = re.search(revision_regex, gethtml(url)).group("revision")
-    except IndexError:
-        try:
-            url += '?skip_wall=1'  # perv
-            html = gethtml(url)
-            player_revision = re.search(revision_regex, html).group("revision")
-        except IndexError:
-            open('debug.html', 'w').write(html.encode('utf-8'))
-            sys.exit('Sorry, but it looks like something went wrong with accessing the Crunchyroll page. Please make an issue on GitHub and attach debug.html which should be in the folder.')
-    return player_revision
+#def playerrev(url):
+#    global player_revision 
+#
+#    revision_regex = r"swfobject.embedSWF\(\"(?:.+)'(?P<revision>[\d.]+)'(?:.+)\)"
+#    try:
+#        player_revision = re.search(revision_regex, gethtml(url)).group("revision")
+#    except IndexError:
+#        try:
+#            url += '?skip_wall=1'  # perv
+#            html = gethtml(url)
+#            player_revision = re.search(revision_regex, html).group("revision")
+#        except IndexError:
+#            open('debug.html', 'w').write(html.encode('utf-8'))
+#            sys.exit('Sorry, but it looks like something went wrong with accessing the Crunchyroll page. Please make an issue on GitHub and attach debug.html which should be in the folder.')
+#    return player_revision
 
 
 def gethtml(url):
@@ -107,7 +107,7 @@ def getxml(req, med_id):
             except:
                 sleep(10)  # sleep so we don't overload crunblocker
                 session.cookies['sess_id'] = requests.get('http://www.crunblocker.com/sess_id.php').text
-    headers = {'Referer': 'http://static.ak.crunchyroll.com/flash/' + player_revision + '/StandardVideoPlayer.swf',
+    headers = {'Referer': 'http://static.ak.crunchyroll.com/versioned_assets/ChromelessPlayerApp.17821a0e.swf',
                'Host': 'www.crunchyroll.com', 'Content-type': 'application/x-www-form-urlencoded',
                'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; rv:26.0) Gecko/20100101 Firefox/26.0)'}
     res = session.post(url, params=payload, headers=headers)

--- a/crunchy-xml-decoder/decode.py
+++ b/crunchy-xml-decoder/decode.py
@@ -40,7 +40,7 @@ Booting up...
         page_url = raw_input('Please enter Crunchyroll video URL:\n')
 
     lang1, lang2, forcesub, forceusa, localizecookies, vquality, onlymainsub = altfuncs.config()
-    player_revision = altfuncs.playerrev(page_url)
+    #player_revision = altfuncs.playerrev(page_url)
     html = altfuncs.gethtml(page_url)
 
     h = HTMLParser.HTMLParser()

--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -25,10 +25,14 @@ from unidecode import unidecode
 
 def video():
     print 'Downloading video...'
-    cmd = '.\\video-engine\\rtmpdump -r "' + url1 + '" -a "' \
-          + url2 + '" -f "WIN 11,8,800,50" -m 15 -W "http://static.ak.crunchyroll.com/flash/' \
-          + player_revision + '/ChromelessPlayerApp.swf" -p "' + page_url2 + '" -y "' + filen + \
-          '" -o ".\\export\\' + title + '.flv"'
+    cmd = ['.\\video-engine\\rtmpdump',
+           '-r', url1, '-a', url2,
+           '-f', 'WIN 11,8,800,50',
+           '-m', '15',
+           '-W', 'http://static.ak.crunchyroll.com/versioned_assets/ChromelessPlayerApp.17821a0e.swf',
+           '-p', page_url2,
+           '-y', filen,
+           '-o', '.\\export\\{}.flv'.format(title)]
     error = subprocess.call(cmd)
     # error = 0
 
@@ -157,7 +161,8 @@ def subtitles(eptitle):
 # ----------
 
 def ultimate(page_url, seasonnum, epnum):
-    global url1, url2, filen, player_revision, title, media_id, lang1, lang2, hardcoded, forceusa, page_url2
+    global url1, url2, filen, title, media_id, lang1, lang2, hardcoded, forceusa, page_url2
+    #global player_revision
 
     print '''
 --------------------------
@@ -199,7 +204,7 @@ Booting up...
     #lang1, lang2 = altfuncs.config()
     #lang1, lang2, forcesub = altfuncs.config()
     lang1, lang2, forcesub, forceusa, localizecookies, vquality, onlymainsub = altfuncs.config()
-    player_revision = altfuncs.playerrev(page_url)
+    #player_revision = altfuncs.playerrev(page_url)
     html = altfuncs.gethtml(page_url)
 
     h = HTMLParser.HTMLParser()


### PR DESCRIPTION
This should fix #52.

So apparently Crunchyroll updated their web player URL path.
It looks like what could variably change in the URL is the `ChromelessPlayerApp.17821a0e.swf` part but so far it has been constant while looking for it.