### PR TITLE
HLS, new login and portability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 crunchy-xml-decoder
 ===================
 
-Requires PyCrypto (http://www.voidspace.org.uk/python/modules.shtml#pycrypto) and lxml (https://pypi.python.org/pypi/lxml/3.2.5)
-if crunchy-xml-decoder could automatically install PyCrypto and lxml use the above link to download manually 
+Requires Python modules:
+- PyCrypto (http://www.voidspace.org.uk/python/modules.shtml#pycrypto)
+- lxml (https://pypi.python.org/pypi/lxml/3.2.5)
+- m3u8 (https://pypi.python.org/pypi/m3u8/)
+
+crunchy-xml-decoder will try to install PyCrypto and lxml automatically,
+if they are missing. m3u8 can be installed using PIP.
 
 
 This is a composite of various scripts required to download video files from CrunchyRoll 
@@ -13,14 +18,15 @@ INSTRUCTIONS:
 
     Pre-Setup (Only need to do these once.):
     1.  Install Python 2.7.5.
-    2.  Run crunchy-xml-decoder.bat or crunchy-xml-decoder.py to generate necessary files (settings.ini and cookies)
-    3.  choices	from the option 
+    2.  Run pip install m3u8.
+    3.  Run crunchy-xml-decoder.bat or crunchy-xml-decoder.py to generate necessary files (settings.ini and cookies)
+    4.  choices	from the option 
 
     Per-Video Process:
     1.  Copy the URL of the CrunchyRoll video you want to download from your web browser
     2.  Run crunchy-xml-decoder.bat or crunchy-xml-decoder.py choice 1 and paste link
-    8.  Download will start automatically. Everything is automated.
-    11. Browse to the 'export' folder to view the completed file.
+    3.  Download will start automatically. Everything is automated.
+    4. Browse to the 'export' folder to view the completed file.
 
     SPECIAL NOTE: There is another batch file in the _run folder..
         Run crunchy-xml-decoder.bat or crunchy-xml-decoder.py choice 2 and paste link
@@ -31,8 +37,8 @@ WHAT IS THE POINT OF THIS SCRIPT? WHAT IS IT ACTUALLY DOING?:
 
     The process of getting a working download from CrunchyRoll is effectively doing the following:
         - Downloading and decrypting subtitles
-        - Downloading the video as FLV
-        - Splitting the FLV file into 264 video and aac audio
+        - Downloading the video as FLV or MPEG-TS
+        - Splitting the FLV/TS file into 264 video and aac audio
         - Merging video, audio, and subtitles into a mkv file
         - Naming the new video something other than 'video.mkv'
 

--- a/crunchy-xml-decoder/crunchyDec.py
+++ b/crunchy-xml-decoder/crunchyDec.py
@@ -10,7 +10,10 @@ class CrunchyDec:
         pass
 
     def returnsubs(self, xml):
-        _id, _iv, _data = self.strain(xml)
+        s = self.strain(xml)
+        if s is None:
+             return
+        _id, _iv, _data = s
         print "Attempting to decrypt subtitles..."
         decryptedsubs = self.decode(_id, _iv, _data)
 

--- a/crunchy-xml-decoder/decode.py
+++ b/crunchy-xml-decoder/decode.py
@@ -8,7 +8,7 @@ Thanks!
 """
 
 # import lxml
-import os
+import os.path
 import re
 import shutil
 import sys
@@ -45,7 +45,7 @@ Booting up...
 
     #h = HTMLParser.HTMLParser()
     title = re.findall('<title>(.+?)</title>', html)[0].replace('Crunchyroll - Watch ', '')
-    if len(os.getcwd()+'\\export\\'+title+'.ass') > 255:
+    if len(os.path.join('export', title+'.ass') > 255:
         title = re.findall('^(.+?) \- ', title)[0]
 
     ### Taken from http://stackoverflow.com/questions/6116978/python-replace-multiple-strings ###
@@ -122,7 +122,7 @@ Booting up...
             xmlsub = altfuncs.getxml('RpcApiSubtitle_GetXml', i)
             formattedsubs = CrunchyDec().returnsubs(xmlsub)
             #subfile = open(eptitle + '.ass', 'wb')
-            subfile = open('.\\export\\'+title+'['+sub_id3.pop(0)+']'+sub_id4.pop(0)+'.ass', 'wb')
+            subfile = open(os.path.join('export', title+'['+sub_id3.pop(0)+']'+sub_id4.pop(0)+'.ass'), 'wb')
             subfile.write(formattedsubs.encode('utf-8-sig'))
             subfile.close()
         #shutil.move(title + '.ass', os.path.join(os.getcwd(), 'export', ''))

--- a/crunchy-xml-decoder/decode.py
+++ b/crunchy-xml-decoder/decode.py
@@ -121,6 +121,8 @@ Booting up...
             #xmlsub = altfuncs.getxml('RpcApiSubtitle_GetXml', sub_id)
             xmlsub = altfuncs.getxml('RpcApiSubtitle_GetXml', i)
             formattedsubs = CrunchyDec().returnsubs(xmlsub)
+            if formattedsubs is None:
+                continue
             #subfile = open(eptitle + '.ass', 'wb')
             subfile = open(os.path.join('export', title+'['+sub_id3.pop(0)+']'+sub_id4.pop(0)+'.ass'), 'wb')
             subfile.write(formattedsubs.encode('utf-8-sig'))

--- a/crunchy-xml-decoder/decode.py
+++ b/crunchy-xml-decoder/decode.py
@@ -45,7 +45,7 @@ Booting up...
 
     #h = HTMLParser.HTMLParser()
     title = re.findall('<title>(.+?)</title>', html)[0].replace('Crunchyroll - Watch ', '')
-    if len(os.path.join('export', title+'.ass') > 255:
+    if len(os.path.join('export', title+'.ass')) > 255:
         title = re.findall('^(.+?) \- ', title)[0]
 
     ### Taken from http://stackoverflow.com/questions/6116978/python-replace-multiple-strings ###

--- a/crunchy-xml-decoder/hls.py
+++ b/crunchy-xml-decoder/hls.py
@@ -1,0 +1,102 @@
+import sys
+import errno
+import m3u8
+import urllib2
+from Crypto.Cipher import AES
+import StringIO
+import socket
+import os
+
+blocksize = 16384
+
+class resumable_fetch:
+    def __init__(self, uri, cur, total):
+        self.uri = uri
+        self.cur = cur
+        self.total = total
+        self.offset = 0
+        self._restart()
+        self.file_size = int(self.stream.info().get('Content-Length', -1))
+        if self.file_size <= 0:
+            print "Invalid file size"
+            sys.exit()
+
+    def _progress(self):
+        sys.stdout.write('\x1b[2K\r%d/%d' % (self.cur, self.total))
+        sys.stdout.flush()
+
+    def _restart(self):
+        req = urllib2.Request(self.uri)
+        if self.offset:
+            req.headers['Range'] = 'bytes=%s-' % (self.offset, )
+        while True:
+            try:
+                self.stream = urllib2.urlopen(req, timeout = 30)
+                break
+            except socket.timeout:
+                continue
+            except socket.error, e:
+                if e.errno != errno.ECONNRESET:
+                    raise
+
+    def read(self, n):
+        buffer = []
+        while self.offset < self.file_size:
+            try:
+                data = self.stream.read(min(n, self.file_size - self.offset))
+                self.offset += len(data)
+                n -= len(data)
+                buffer.append(data)
+                if n == 0 or data:
+                        break
+            except socket.timeout:
+                self._progress()
+                self._restart()
+            except socket.error as e:
+                if e.errno != errno.ECONNRESET:
+                    raise
+                self._progress()
+                self._restart()
+        return "".join(buffer)
+
+def copy_with_decrypt(input, output, key):
+      iv = str(key.iv)[2:]
+      aes = AES.new(key.key_value, AES.MODE_CBC, iv.decode('hex'))
+      while True:
+          data = input.read(blocksize)
+          if not data:
+              break
+          output.write(aes.decrypt(data))
+
+def fetch_streams(output, video):
+    output = open(output, 'wb')
+    for n, seg in enumerate(video.segments):
+        sys.stdout.write('\x1b[2K\r%d/%d' % (n + 1, len(video.segments)))
+        sys.stdout.flush()
+        raw = resumable_fetch(seg.uri, n+1, len(video.segments))
+        copy_with_decrypt(raw, output, video.key)
+        size = output.tell()
+        if size % 188 != 0:
+            size = size // 188 * 188
+            output.seek(size)
+            output.truncate(size)
+    print '\n'
+
+def fetch_encryption_key(video):
+    assert video.key.method == 'AES-128'
+    video.key.key_value = urllib2.urlopen(url = video.key.uri).read()
+
+def find_best_video(uri):
+    playlist = m3u8.load(uri)
+    if not playlist.is_variant:
+        return playlist
+    best_stream = playlist.playlists[0]
+    for stream in playlist.playlists:
+        if stream.stream_info.bandwidth == 'max' or stream.stream_info.bandwidth > best_stream.stream_info.bandwidth:
+            best_stream = stream
+    return find_best_video(best_stream.absolute_uri)
+
+def video_hls(uri, output):
+    video = find_best_video(uri)
+    fetch_encryption_key(video)
+    fetch_streams(output, video)

--- a/crunchy-xml-decoder/login.py
+++ b/crunchy-xml-decoder/login.py
@@ -14,12 +14,10 @@ def getuserstatus(session=''):
             session = requests.session()
             session.cookies = cookies
             del session.cookies['c_visitor']
-    #print session.cookies #session = requests.session()
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:34.0) Gecko/20100101 Firefox/34.0',
                'Connection': 'keep-alive'}
     site = session.get('https://www.crunchyroll.com/acct/membership', headers=headers, verify=True).text
-    #open('tempfile','w').write(site).encoding('UTF-8')
-    #print site.encode('utf-8')
+    #open('tempfile','w').write(site.encode('UTF-8'))
     if re.search(re.escape('      ga(\'set\', \'dimension5\', \'registered\');'), site):
         status = 'Free Member'
     elif re.search(re.escape('      ga(\'set\', \'dimension5\', \'premium\');'), site):
@@ -35,39 +33,29 @@ def login(username, password):
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:34.0) Gecko/20100101 Firefox/34.0',
                'Connection': 'keep-alive'}
     session = requests.session()
-    session.get('http://www.crunchyroll.com/', headers=headers)
+    res_get = session.get('https://www.crunchyroll.com/login', headers=headers)
 
+    s = re.search('name="login_form\\[_token\\]" value="([^"]*)"', res_get.text)
+    if s is None:
+       print 'CSRF token not found'
+       sys.exit()
+    token = s.group(1)
 
-    headers = {'Referer': 'https://www.crunchyroll.com/login',
-               'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:34.0) Gecko/20100101 Firefox/34.0',
-               'Content-Type': 'application/x-www-form-urlencoded'}
+    payload = {'login_form[redirect_url]': '/',
+               'login_form[name]': username,
+               'login_form[password]': password,
+               'login_form[_token]': token}
 
-    payload = {'formname': 'RpcApiUser_Login', 'fail_url': 'http://www.crunchyroll.com/login',
-               'name': username, 'password': password}
-    res = session.post('https://www.crunchyroll.com/?a=formhandler', data=payload, headers=headers).text
+    res_post = session.post('https://www.crunchyroll.com/login', data=payload, headers=headers, allow_redirects = False)
+    if res_post.status_code != 302:
+      print 'Login failed'
+      sys.exit()
+
     for c in session.cookies:
         c.expires = 9999999999  # Saturday, November 20th 2286, 17:46:39 (GMT)
 
     del session.cookies['c_visitor']
-    del session.cookies['sess_id']
 
-    #headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:34.0) Gecko/20100101 Firefox/34.0',
-    #           'Connection': 'keep-alive'}
-    #url = 'http://www.crunchyroll.com/'
-    #site = session.get(url, headers=headers).text
-    #print session.get('https://www.crunchyroll.com/acct/membership/', headers=headers, verify=True).text.encode('utf-8')
-    #print getuserstatus(session)
-    #if re.search(username+'(?i)', site):
-    #    if username == '':
-    #        print 'Login as Guest.'
-    #    else:
-    #        print 'Login successful.'
-    #    pickle.dump(requests.utils.dict_from_cookiejar(session.cookies), open('cookies', 'w'))
-    #    with open('cookies', 'w') as f:
-    #        pickle.dump(requests.utils.dict_from_cookiejar(session.cookies), f)
-    #else:
-    #    print 'Login failed.'
-    #    sys.exit()
     userstatus = getuserstatus(session)
     if username != '' and userstatus[1] == 'Guest':
         print 'Login failed.'

--- a/crunchy-xml-decoder/manga.py
+++ b/crunchy-xml-decoder/manga.py
@@ -334,7 +334,7 @@ for i in mangalist:
         else:
             zipname = manga_name+' '+vol_num+' #'+cnum+'.cbz'
 
-        if os.path.exists(manga_name+'\\'+zipname):
+        if os.path.exists(os.path.join(manga_name, zipname)):
             continue
 
         # print 'WE GOT '+str(c['number'])+' (and high hopes)'
@@ -345,10 +345,10 @@ for i in mangalist:
 
         try:
             covername = manga_name+' '+vol_num+'.jpg'
-            if not os.path.exists(manga_name+'\\'+covername):
+            if not os.path.exists(os.path.join(manga_name, covername)):
                 cover = session.get(url=comic['volume']['encrypted_image_url']).content
                 open(covername, 'wb').write(decrypt(cover))
-                shutil.move(covername, manga_name+'\\'+covername)
+                shutil.move(covername, os.path.join(manga_name, covername))
         except TypeError:
             pass
 
@@ -378,4 +378,4 @@ for i in mangalist:
             # sleep(0.5)
         myzip.close()
 
-        shutil.move(zipname, manga_name+'\\'+zipname)
+        shutil.move(zipname, os.path.join(manga_name, zipname))

--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -153,6 +153,8 @@ def subtitles(eptitle):
 			#xmlsub = altfuncs.getxml('RpcApiSubtitle_GetXml', sub_id)
 			xmlsub = altfuncs.getxml('RpcApiSubtitle_GetXml', i)
 			formattedsubs = CrunchyDec().returnsubs(xmlsub)
+			if formattedsubs is None:
+			    continue
 			#subfile = open(eptitle + '.ass', 'wb')
 			subfile = open('.\\export\\'+title+'['+sub_id3.pop(0)+']'+sub_id4.pop(0)+'.ass', 'wb')
 			subfile.write(formattedsubs.encode('utf-8-sig'))

--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -108,7 +108,7 @@ def subtitles(eptitle):
 				sub_id = re.findall("id=([0-9]+)' title='\["+re.escape(unidecode(lang2)), xmllist)[0]
 				lang = lang2
 			except IndexError:
-				lang ='[English (US)]'
+				lang ='English'
     sub_id3 = [word.replace('[English (US)]','eng') for word in sub_id3]
     sub_id3 = [word.replace('[Deutsch]','deu') for word in sub_id3]
     sub_id3 = [word.replace('[Portugues (Brasil)]','por') for word in sub_id3]

--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -289,8 +289,13 @@ Booting up...
         mkvmerge = os.path.join("video-engine", "mkvmerge.exe")
         filename_output = os.path.join("export", title + '[' + heightp.strip() +'].mkv')
         subtitle_input = []
+        if os.path.isfile(mkvmerge):
+            with_wine = os.name != 'nt'
+        else:
+            mkvmerge = "mkvmerge"
+            with_wine = False
         cmd = [mkvmerge, "-o", filename_output, '--language', '0:jpn', '--language', '1:jpn', '-a', '1', '-d', '0', video_input, '--title', title]
-        if os.name != 'nt':
+        if with_wine:
             cmd.insert(0, 'wine')
         if not hardcoded:
             sublang = {u'Español (Espana)': 'spa_spa', u'Français (France)': 'fre', u'Português (Brasil)': 'por',


### PR DESCRIPTION
This PR includes three things necessary for me to test each step correctly on Linux:
- use os.path.* for handling \ vs / difference
- run mkvmerge.exe and rtmpdump.exe via wine when not on Windows
- integrate a slightly cleaned up version of the HLS patch
- teach login to use the new CSRF-safe login format.

Note: manga.py hasn't been updated for the login step yet. Ideally, it should reuse the same logic.