### PR TITLE
HLS does not work with Python 2.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ that have been automated with a batch file.
 INSTRUCTIONS:
 
     Pre-Setup (Only need to do these once.):
-    1.  Install Python 2.7.5.
+    1.  Install Python 2.7.9.
     2.  Run pip install m3u8.
     3.  Run crunchy-xml-decoder.bat or crunchy-xml-decoder.py to generate necessary files (settings.ini and cookies)
     4.  choices	from the option 


### PR DESCRIPTION
On windows, python 2.7.9 is the oldest version that allows hls to work properly on windows. Python 2.7.9 has a backported openssl from python 3.4 which doesn't cause hls to error out like the openssl from python 2.7.5